### PR TITLE
feature/external display fix

### DIFF
--- a/Centered Game Text/shared.css
+++ b/Centered Game Text/shared.css
@@ -12,7 +12,7 @@
 }
 
 .basicgamecarousel_CarouselGameLabelWrapper_ZkD6W {
-    width: auto !important;
+    width: 100% !important;
 }
 
 .basicgamecarousel_CarouselGameLabel_3CKji > .appportrait_PortraitMessage_3gwMk {

--- a/switch_like_home/nofriends.css
+++ b/switch_like_home/nofriends.css
@@ -1,3 +1,4 @@
-div .basicgamecarousel_BasicGameCarousel_3MdH5 {
-    padding-top: 215px;
+.gamepadhomerecentgames_RecentGamesInnerContainer_282X0 {
+    /* Screen Height - (Header + Footer) - header padding */
+    height: calc(100vh - 80px - 14px);
 }

--- a/switch_like_home/shared.css
+++ b/switch_like_home/shared.css
@@ -3,7 +3,7 @@
     height: calc(100vh - 80px - 14px - 58px);
 }
 
-div .basicgamecarousel_BasicGameCarousel_3MdH5 {
+.gamepadhomerecentgames_RecentGamesInnerContainer_282X0 .basicgamecarousel_BasicGameCarousel_3MdH5 {
     bottom: 0px;
     position: absolute !important;
 }

--- a/switch_like_home/shared.css
+++ b/switch_like_home/shared.css
@@ -1,11 +1,17 @@
+.gamepadhomerecentgames_RecentGamesInnerContainer_282X0 {
+    /* Screen Height - (Header + Footer) - header padding - friend bar */
+    height: calc(100vh - 80px - 14px - 58px);
+}
+
 div .basicgamecarousel_BasicGameCarousel_3MdH5 {
-    padding-top: 158px;
-    height: 100% !important;
-    padding-bottom: 0px;
+    bottom: 0px;
+    position: absolute !important;
 }
 
 .basicgamecarousel_CarouselGameLabelWrapper_ZkD6W {
-    margin-top: -265px;
+    position: absolute;
+    top: -52px;
+    padding-top: 0;
 }
 
 .basicgamecarousel_BasicGameCarousel_3MdH5 {


### PR DESCRIPTION
### Testing: 
 - [x] Tested on Steam Deck
 - [x] Tested on External Display

## Switch Like Home

### Before
<img width="609" alt="image" src="https://user-images.githubusercontent.com/15234414/195891475-ddfc6247-c80a-4038-a330-cd443cf256e4.png">

### After
<img width="609" alt="image" src="https://user-images.githubusercontent.com/15234414/195895960-33b88453-2c1d-4418-800f-0feaee4d9f24.png">

### After + No friends
<img width="609" alt="image" src="https://user-images.githubusercontent.com/15234414/195891618-6dbcab52-7977-4fe4-941d-0e337b5f14d0.png">

## Centered Game Text + Switch Like Home

### Before
<img width="609" alt="image" src="https://user-images.githubusercontent.com/15234414/195891831-6166af23-5414-4b40-b081-5cc0c8308bfb.png">

### After
<img width="609" alt="image" src="https://user-images.githubusercontent.com/15234414/195891889-b1db2fb2-5740-40f3-8f76-64a803ea9f93.png">

## Centered Game Text
**This change does not affect the function of Centered Game Text when it is used solo:**

### Before
<img width="609" alt="image" src="https://user-images.githubusercontent.com/15234414/195892195-46882c80-d5a8-4849-919c-3083a9cf90d7.png">

### After 
<img width="609" alt="image" src="https://user-images.githubusercontent.com/15234414/195892211-029a6bca-59de-4e7b-be59-73cb6c28e841.png">
