### PR TITLE
Clean Gameview: Add option to enable blur

### DIFF
--- a/Clean Gameview/blur.css
+++ b/Clean Gameview/blur.css
@@ -1,0 +1,3 @@
+.basicappdetailssectionstyler_PlaySection_3scbH {
+    backdrop-filter: blur(8px);
+}

--- a/Clean Gameview/theme.json
+++ b/Clean Gameview/theme.json
@@ -18,6 +18,16 @@
                 },
                 "No": {}
             }
+        },
+        "Use Blur": {
+            "type": "checkbox",
+            "default": "No",
+            "values": {
+                "Yes": {
+                    "blur.css": ["SP"]
+                },
+                "No": {}
+            }
         }
     }
 }


### PR DESCRIPTION
# Clean Gameview

Adds an option to enable blur on the game bar.

![use blur](https://user-images.githubusercontent.com/68391508/202553949-9a3f536b-0d88-48df-8fc2-eea405567927.png)
![blur](https://user-images.githubusercontent.com/68391508/202553974-cbee2e1e-c8ce-4ae1-b07a-5cfef0066ee5.png)
