### PR TITLE
Add option to ignore footer in Clean Game View

### DIFF
--- a/Clean Gameview/shared.css
+++ b/Clean Gameview/shared.css
@@ -1,7 +1,6 @@
 :root {
-    --CGV-top-panel-height: calc(100vh - 80px - 40px);
-    --CGV-image-height: calc(100vh - 40px);
-    --CGV-play-anim-height: 58vw;
+    --CGV-top-panel-height: calc(100vh - 80px - var(--CGV-footer-height));
+    --CGV-image-height: calc(100vh - var(--CGV-footer-height));
 }
 
 .BasicUI .sharedappdetailsheader_TopCapsule_2meE3 {

--- a/Clean Gameview/theme.json
+++ b/Clean Gameview/theme.json
@@ -28,6 +28,20 @@
                 },
                 "No": {}
             }
+        },
+        "Ignore Footer": {
+            "type": "checkbox",
+            "default": "No",
+            "values": {
+                "Yes": {
+                    "--CGV-footer-height": ["0px", "SP"],
+                    "--CGV-play-anim-height": ["100vh", "SP"]
+                },
+                "No": {
+                    "--CGV-footer-height": ["40px", "SP"],
+                    "--CGV-play-anim-height": ["58vw", "SP"]
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This option is to have better support mixing other themes such as Art Hero or Delly Footer that make the footer smaller and/or transparent.

Before:
![image](https://user-images.githubusercontent.com/4614486/236066296-3aa385ca-7c31-4b19-85cd-cf541f5331de.png)

After:
![image](https://user-images.githubusercontent.com/4614486/236066323-823ed3c8-8583-4593-ba9d-47539397acae.png)
