### PR TITLE
Checkbox for Logo

### DIFF
--- a/Clean Gameview/shared.css
+++ b/Clean Gameview/shared.css
@@ -21,11 +21,6 @@
     height: var(--CGV-play-anim-height);
 }
 
-.sharedappdetailsheader_BoxSizer_30GVp {
-    top: 80% !important;
-    max-height: 120px;
-}
-
 .sharedappdetailsheader_TitleSection_1P_tv {
     padding: 0;
 }

--- a/Clean Gameview/smallerlogo.css
+++ b/Clean Gameview/smallerlogo.css
@@ -1,0 +1,4 @@
+.sharedappdetailsheader_BoxSizer_30GVp {
+    top: 80% !important;
+    max-height: 120px;
+}

--- a/Clean Gameview/theme.json
+++ b/Clean Gameview/theme.json
@@ -9,6 +9,16 @@
         "shared.css": ["SP"]
     },
     "patches": {
+        "Smaller Logo": {
+            "type": "checkbox",
+            "default": "Yes",
+            "values": {
+                "Yes": {
+                    "smallerlogo.css": ["SP"]
+                },
+                "No": {}
+            }
+        },
         "Show Steam Cloud": {
             "type": "checkbox",
             "default": "No",


### PR DESCRIPTION
Hi there!

I moved the BoxSizer element into its own css file and added a toggle in theme.json for it. The default behavior is the same as before, but this also allows it to be easily turned off if someone wants the full sized logos instead.

Thanks!