### PR TITLE
Add No Gameview Tabs

### DIFF
--- a/No Gameview Tabs/.gitignore
+++ b/No Gameview Tabs/.gitignore
@@ -1,0 +1,2 @@
+._*
+config_USER.json

--- a/No Gameview Tabs/LICENSE
+++ b/No Gameview Tabs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Derek Stavis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/No Gameview Tabs/gameview.css
+++ b/No Gameview Tabs/gameview.css
@@ -1,0 +1,18 @@
+.BasicUI .basicappdetailssectionstyler_AppDetailsContainer_2-ns_ {
+  display: none;
+  visibility: hidden;
+}
+
+.BasicUI .basicappdetailssectionstyler_AppDetailsContainer_2-ns_ .Focusable {
+  display: none;
+}
+
+.gamepadhomerecentgames_RecentGamesBackgroundFadeGradient_1ksIq {
+  display: none;
+}
+
+.gamepadhomerecentgames_RecentGamesBackgroundImages_30D-8
+  .gamepadhomerecentgames_RecentGamesBackground_1SRox {
+  filter: none;
+  opacity: 0.6;
+}

--- a/No Gameview Tabs/theme.json
+++ b/No Gameview Tabs/theme.json
@@ -1,0 +1,13 @@
+{
+    "name": "No Gameview Tabs",
+    "author": "derekss",
+    "manifest_version": 5,
+    "target": "Other",
+    "description": "Remove tabs from game view",
+    "inject": {
+        "gameview.css": ["bigpicture"]
+    },
+    "flags": [
+      "REQUIRE_NAV_PATCH"
+    ]
+}


### PR DESCRIPTION
Adds a theme to remove game view tabs. They are annoying and interfere with Clean Gameview when I unintentionally scroll down on analog. I'm also glad to add this option to the Clean Gameview theme but kept it separate for now.