### PR TITLE
Skinny Window Header Fix

### DIFF
--- a/Skinny Window Header/custom_icons.css
+++ b/Skinny Window Header/custom_icons.css
@@ -53,7 +53,7 @@
     -webkit-mask-image: url(/themes_custom/Skinny%20Window%20Header/icons/tv-solid.svg);
     width: 0px;
     min-width: 18px; 
-    margin-right: 8px;
+    margin-right: 16px;
     margin-top: 1px;
 }
 

--- a/Skinny Window Header/steam.css
+++ b/Skinny Window Header/steam.css
@@ -160,3 +160,7 @@
     background: transparent;
 }
 
+.bottombar_AddGameButton_2foCk {
+    padding: 0px 0px 0px 0px
+}
+


### PR DESCRIPTION
This is to fix the spacing of the icons in the top bar as previously, these were overlapping. This might not be the correct way to fix it but it works.