### PR TITLE
fix: Clean Gameview logo misalign

### DIFF
--- a/Clean Gameview/lockedlogo.css
+++ b/Clean Gameview/lockedlogo.css
@@ -1,4 +1,5 @@
 .sharedappdetailsheader_BoxSizer_30GVp {
-    top: 80% !important;
-    max-height: 120px;
+    --logo-max-height: 120px;
+    top: calc(100vh - var(--logo-max-height) * 1.3 - var(--CGV-play-bar-height) - var(--CGV-footer-height)) !important;
+    max-height: var(--logo-max-height);
 }


### PR DESCRIPTION
# Before

<img width="1026" alt="Screenshot 2024-06-14 at 1 53 55 AM" src="https://github.com/suchmememanyskill/Steam-Deck-Themes/assets/38860226/ba798c92-1c38-47f0-98ea-2b236e83f61d">

# After

<img width="1026" alt="Screenshot 2024-06-14 at 1 54 23 AM" src="https://github.com/suchmememanyskill/Steam-Deck-Themes/assets/38860226/524327d7-a853-4718-a439-54325cf6f039">
